### PR TITLE
invalidate object if connection failed.

### DIFF
--- a/romac4j/src/main/java/com/rakuten/rit/roma/romac4j/connection/RomaSocketPool.java
+++ b/romac4j/src/main/java/com/rakuten/rit/roma/romac4j/connection/RomaSocketPool.java
@@ -76,6 +76,23 @@ public class RomaSocketPool {
         }
     }
 
+    public void invalidateConnection(Connection con) {
+        GenericObjectPool<Connection> pool = poolMap.get(con.getNodeId());
+        if (pool != null) {
+            synchronized(pool) {
+                if(poolMap.containsKey(con.getNodeId())) {
+                    try {
+                        pool.invalidateObject(con);
+                        con.forceClose();
+                        return;
+                    } catch (Exception e) {
+                        log.error("invalidateConnection() : " + e.getMessage());
+                    }
+                }
+            }
+        }
+    }
+
     public void returnConnection(Connection con) {
         try {
             con.setSoTimeout(0);

--- a/romac4j/src/main/java/com/rakuten/rit/roma/romac4j/routing/Routing.java
+++ b/romac4j/src/main/java/com/rakuten/rit/roma/romac4j/routing/Routing.java
@@ -123,6 +123,7 @@ public final class Routing extends Thread {
             return;
         }
         failCount(con.getNodeId());
+        sps.invalidateConnection(con);
         con.forceClose();
     }
 

--- a/romac4j/src/test/java/com/rakuten/rit/roma/romac4j/connection/RomaSocketPoolTest.java
+++ b/romac4j/src/test/java/com/rakuten/rit/roma/romac4j/connection/RomaSocketPoolTest.java
@@ -1,0 +1,53 @@
+package com.rakuten.rit.roma.romac4j.connection;
+
+import junit.framework.TestCase;
+
+/**
+ * Created by yinchin.chen on 10/27/16.
+ */
+public class RomaSocketPoolTest extends TestCase {
+
+    RomaSocketPool FIXTURE;
+    String nodeId = "localhost_11211";
+
+    public void setUp() {
+        RomaSocketPool.init();
+        FIXTURE = RomaSocketPool.getInstance();
+    }
+
+    public void tearDown(){
+        FIXTURE.deleteConnection(nodeId);
+    }
+
+    public void testConnection() throws Exception {
+        // get connection1 and return connection1
+        Connection con1 = FIXTURE.getConnection(nodeId);
+        FIXTURE.returnConnection(con1);
+
+        // get connection2
+        Connection con2 = FIXTURE.getConnection(nodeId);
+        // con1 must equal con2
+        assertEquals(con1, con2);
+
+        // invalid con1
+        FIXTURE.invalidateConnection(con1);
+        // get con3
+        Connection con3 = FIXTURE.getConnection(nodeId);
+        FIXTURE.returnConnection(con3);
+        assertNotSame(con2, con3);
+        // test connection.
+        assertTrue(con1.isClosed());
+        assertTrue(con3.isConnected());
+    }
+
+    public void testGetConnections() throws Exception{
+        Connection con1 = FIXTURE.getConnection(nodeId);
+        Connection con2 = FIXTURE.getConnection(nodeId);
+        Connection con3 = FIXTURE.getConnection(nodeId);
+        Connection con4 = FIXTURE.getConnection(nodeId);
+        FIXTURE.returnConnection(con1);
+        FIXTURE.returnConnection(con2);
+        FIXTURE.returnConnection(con3);
+        FIXTURE.returnConnection(con4);
+    }
+}

--- a/romac4j/src/test/java/com/rakuten/rit/roma/romac4j/connection/RomaSocketPoolTest.java
+++ b/romac4j/src/test/java/com/rakuten/rit/roma/romac4j/connection/RomaSocketPoolTest.java
@@ -29,15 +29,15 @@ public class RomaSocketPoolTest extends TestCase {
         // con1 must equal con2
         assertEquals(con1, con2);
 
-        // invalid con1
-        FIXTURE.invalidateConnection(con1);
+        // invalid con2
+        FIXTURE.invalidateConnection(con2);
         // get con3
         Connection con3 = FIXTURE.getConnection(nodeId);
-        FIXTURE.returnConnection(con3);
         assertNotSame(con2, con3);
         // test connection.
-        assertTrue(con1.isClosed());
+        assertTrue(con2.isClosed());
         assertTrue(con3.isConnected());
+        FIXTURE.returnConnection(con3);
     }
 
     public void testGetConnections() throws Exception{


### PR DESCRIPTION
If connection failed, then there will have a lot of connections in connection pools and cause too much file description error.
